### PR TITLE
Change the link in the readme from a specific release to the latest release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It seems the Pi 5 is unable to run in monitor mode, will keep you updated on thi
 If you are using an older 32-bit version Raspberry Pi, ZeroWH, use this [fork](https://github.com/jayofelony/pwnagotchi-torch/releases/tag/v2.6.4) and make sure you download the `armhf` version.
 
 ---
-Download the latest image file [here](https://github.com/jayofelony/pwnagotchi-bookworm/releases/tag/v2.7.9), and let it auto-update from here on out.
+Download the latest image file [here](https://github.com/jayofelony/pwnagotchi-bookworm/releases/latest), and let it auto-update from here on out.
 
 **Use RPi imager to flash, please don't flash a new user as this will mess with logs created.**
   - Select `Use Custom Image`


### PR DESCRIPTION
Changed the link to the latest image to the 'latest release' page, so the readme won't need to be updated with every new release.

## Description
The current readme links specifically to the 2.7.9 image. This pull changes it so that it instead links to the repository's "/releases/latest" page, so the readme won't need updated with each new release.

## Motivation and Context
Currently, clicking the readme will lead the reader to a specific release, and for that matter, one that is already out of date.


## How Has This Been Tested?
Checked that the link works

## Types of changes
Documentation
