### PR TITLE
Added DummyDisplay for arbitrary screen size when headless

### DIFF
--- a/pwnagotchi/ui/display.py
+++ b/pwnagotchi/ui/display.py
@@ -193,6 +193,9 @@ class Display(View):
     def is_inky(self):
         return self._implementation.name == 'inky'
 
+    def is_dummy_display(self):
+        return self._implementation.name == 'dummydisplay'
+
     def is_papirus(self):
         return self._implementation.name == 'papirus'
 

--- a/pwnagotchi/ui/hw/__init__.py
+++ b/pwnagotchi/ui/hw/__init__.py
@@ -1,4 +1,5 @@
 from pwnagotchi.ui.hw.inky import Inky
+from pwnagotchi.ui.hw.dummydisplay import DummyDisplay
 from pwnagotchi.ui.hw.papirus import Papirus
 from pwnagotchi.ui.hw.oledhat import OledHat
 from pwnagotchi.ui.hw.lcdhat import LcdHat
@@ -68,6 +69,9 @@ def display_for(config):
     # config has been normalized already in utils.load_config
     if config['ui']['display']['type'] == 'inky':
         return Inky(config)
+
+    elif config['ui']['display']['type'] == 'dummydisplay':
+        return DummyDisplay(config)
 
     elif config['ui']['display']['type'] == 'papirus':
         return Papirus(config)

--- a/pwnagotchi/ui/hw/dummydisplay.py
+++ b/pwnagotchi/ui/hw/dummydisplay.py
@@ -6,7 +6,7 @@ from pwnagotchi.ui.hw.base import DisplayImpl
 
 class DummyDisplay(DisplayImpl):
     def __init__(self, config):
-        super(DummyDisplay, self).__init__(config, 'inky')
+        super(DummyDisplay, self).__init__(config, 'DummyDisplay')
 
     def layout(self):
         width=480 if 'width' not in self.config else self.config['width']

--- a/pwnagotchi/ui/hw/dummydisplay.py
+++ b/pwnagotchi/ui/hw/dummydisplay.py
@@ -1,0 +1,43 @@
+import logging
+
+import pwnagotchi.ui.fonts as fonts
+from pwnagotchi.ui.hw.base import DisplayImpl
+
+
+class DummyDisplay(DisplayImpl):
+    def __init__(self, config):
+        super(DummyDisplay, self).__init__(config, 'inky')
+
+    def layout(self):
+        width=480 if 'width' not in self.config else self.config['width']
+        height=720 if 'height' not in self.config else self.config['height']
+        fonts.setup(int(height/30), int(height/40), int(height/30), int(height/6), int(height/30), int(height/35))
+        self._layout['width'] = width
+        self._layout['height'] = height
+        self._layout['face'] = (0, int(width/12))
+        self._layout['name'] = (5, int(width/25))
+        self._layout['channel'] = (0, 0)
+        self._layout['aps'] = (int(width/8), 0)
+        self._layout['uptime'] = (width-int(width/12), 0)
+        self._layout['line1'] = [0, int(height/32), width, int(height/32)]
+        self._layout['line2'] = [0, height-int(height/25)-1, width, height-int(height/25)-1]
+        self._layout['friend_face'] = (0, int(height/10))
+        self._layout['friend_name'] = (int(width/12), int(height/10))
+        self._layout['shakes'] = (0, height-int(height/25))
+        self._layout['mode'] = (width-int(width/8), height - int (height/25))
+        lw, lh = fonts.Small.getsize("W")
+        self._layout['status'] = {
+            'pos': (int(width/48), int(height/3)),
+            'font': fonts.status_font(fonts.Small),
+            'max': int(width / lw)
+        }
+        return self._layout
+
+    def initialize(self):
+        return
+
+    def render(self, canvas):
+        return
+
+    def clear(self):
+        return

--- a/pwnagotchi/utils.py
+++ b/pwnagotchi/utils.py
@@ -240,6 +240,8 @@ def load_config(args):
     # the very first step is to normalize the display name, so we don't need dozens of if/elif around
     if config['ui']['display']['type'] in ('inky', 'inkyphat'):
         config['ui']['display']['type'] = 'inky'
+    elif config['ui']['display']['type'] in ('dummy', 'dummydisplay'):
+        config['ui']['display']['type'] = 'dummydisplay'
     elif config['ui']['display']['type'] in ('papirus', 'papi'):
         config['ui']['display']['type'] = 'papirus'
 


### PR DESCRIPTION
Added a "dummy" display type for when headless. Set your desired display size in config.toml

## Description
Added dummydisplay.py and necessary changes to the other UI files to add it as a type of display.  This has no physical device associated. Use is for headless.  You can specify arbitrary width and height in config:

    ui.display.width = 480
    ui.display.height = 720

The UI element positions and fonts are scaled to the size of the display, but is a rough starting point.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to use pwnagotchi on a pi5 with a 4" HDMI "hat", and needed a resolution of 480x720 to make the pwnagotchi webUI exactly fit the screen. I could not find a suitably sized stock screen.
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested on a pi5 with latest pwnagotch-bookworm code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
